### PR TITLE
Subclass YTM Track from YT Track

### DIFF
--- a/src/pycord/wavelink/tracks.py
+++ b/src/pycord/wavelink/tracks.py
@@ -218,7 +218,7 @@ class YouTubeTrack(SearchableTrack):
     thumb = thumbnail
 
 
-class YouTubeMusicTrack(SearchableTrack):
+class YouTubeMusicTrack(YouTubeTrack):
     """A track created using a search to YouTube Music."""
 
     _search_type: ClassVar[str] = "ytmsearch"


### PR DESCRIPTION
So apparently songs on YouTube music are there on Youtube too, with the exact same video id. 
In fact, Youtube Music is just a layer on top of Youtube. 

Subclassing YTM Track from YT Track gives it the thumbnail property. It is used to get the thumbnail of the video