### PR TITLE
Get Spotify Tracks from YTMusic instead of YT

### DIFF
--- a/src/pycord/wavelink/ext/spotify/__init__.py
+++ b/src/pycord/wavelink/ext/spotify/__init__.py
@@ -33,7 +33,7 @@ import aiohttp
 from discord.ext import commands
 
 import pycord.wavelink
-from pycord.wavelink import Node, NodePool, PartialTrack, YouTubeTrack
+from pycord.wavelink import Node, NodePool, PartialTrack, YouTubeMusicTrack
 from pycord.wavelink.utils import MISSING
 
 __all__ = (
@@ -162,7 +162,7 @@ class SpotifyAsyncIterator:
             )
         else:
             track = (
-                await pycord.wavelink.YouTubeTrack.search(
+                await pycord.wavelink.YouTubeMusicTrack.search(
                     query=f'{track["name"]} -' f' {track["artists"][0]["name"]}'
                 )
             )[0]
@@ -233,7 +233,7 @@ class SpotifyClient:
         query: str,
         type: SpotifySearchType = SpotifySearchType.track,
         iterator: bool = False,
-    ) -> Optional[List[YouTubeTrack]]:
+    ) -> Optional[List[YouTubeMusicTrack]]:
 
         if not self._bearer_token or time.time() >= self._expiry:
             await self._get_bearer_token()
@@ -254,7 +254,7 @@ class SpotifyClient:
             data = await resp.json()
 
             if data["type"] == "track":
-                return await pycord.wavelink.YouTubeTrack.search(
+                return await pycord.wavelink.YouTubeMusicTrack.search(
                     f'{data["name"]} - {data["artists"][0]["name"]}'
                 )
 
@@ -262,7 +262,7 @@ class SpotifyClient:
                 tracks = data["tracks"]["items"]
                 return [
                     (
-                        await pycord.wavelink.YouTubeTrack.search(
+                        await pycord.wavelink.YouTubeMusicTrack.search(
                             f'{t["name"]} - {t["artists"][0]["name"]}'
                         )
                     )[0]
@@ -277,7 +277,7 @@ class SpotifyClient:
                     t = track["track"]
                     ret.append(
                         (
-                            await pycord.wavelink.YouTubeTrack.search(
+                            await pycord.wavelink.YouTubeMusicTrack.search(
                                 f'{t["name"]} - {t["artists"][0]["name"]}'
                             )
                         )[0]
@@ -308,8 +308,8 @@ class SpotifyClient:
             return data["tracks"]["items"]
 
 
-class SpotifyTrack(YouTubeTrack):
-    """A track retrieved via YouTube with a Spotify URL/ID."""
+class SpotifyTrack(YouTubeMusicTrack):
+    """A track retrieved via YouTube Music with a Spotify URL/ID."""
 
     @classmethod
     async def search(


### PR DESCRIPTION
## Summary

YouTube Music searches and returns Soundtracks before Music videos. Due to this nature, the quality tends to be better on Youtube Music searches. 

Since Spotify is also primarily soundtracks based music streaming service, getting tracks from YTM seems more logical.

I've tested it to an extent. And the initial results look promising. This should be implemented in conjunction to #24 

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why
- [] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting, examples, ...)