### PR TITLE
Revert "Improve the connect, move, and is_connected methods"

### DIFF
--- a/src/pycord/wavelink/player.py
+++ b/src/pycord/wavelink/player.py
@@ -169,13 +169,9 @@ class Player(discord.VoiceProtocol):
 
     async def connect(self, *, timeout: float, reconnect: bool) -> None:
         await self.guild.change_voice_state(channel=self.channel)
+        self._connected = True
 
-        if self.user.id in [m.id for m in self.channel.members]:
-            self._connected = True
-            logger.info(f"Connected to voice channel:: {self.channel.id}")
-        else:
-            self._connected = False
-            self.channel = None
+        logger.info(f"Connected to voice channel:: {self.channel.id}")
 
     async def disconnect(self, *, force: bool) -> None:
         try:
@@ -199,13 +195,6 @@ class Player(discord.VoiceProtocol):
         """
         await self.guild.change_voice_state(channel=channel)
         logger.info(f"Moving to voice channel:: {channel.id}")
-
-        if self.user.id in [m.id for m in channel.members]:
-            self._connected = True
-            self.channel = channel
-        else:
-            self._connected = False
-            self.channel = None
 
     async def play(
         self, source: abc.Playable, replace: bool = True, start: int = 0, end: int = 0
@@ -259,11 +248,7 @@ class Player(discord.VoiceProtocol):
 
     def is_connected(self) -> bool:
         """Indicates whether the player is connected to voice."""
-        if not self.channel:
-            return False
-        if self.user.id in [m.id for m in self.channel.members]:
-            return True
-        return False
+        return self._connected
 
     def is_playing(self) -> bool:
         """Indicates wether a track is currently being played."""


### PR DESCRIPTION
Reverts Pycord-Development/Pycord.Wavelink#34

The library seems to have broken after the mentioned PR. 1 previous version works perfectly without and code changes

Error-
```py
Traceback (most recent call last):
  File "/home/container/.local/lib/python3.10/site-packages/discord/ext/commands/core.py", line 179, in wrapped
    ret = await coro(*args, **kwargs)
  File "/home/container/Cogs/Music.py", line 142, in play
    await vc.play(vc.queue.get())
  File "/home/container/.local/lib/python3.10/site-packages/pycord/wavelink/player.py", line 247, in play
    "guildId": str(self.guild.id),
  File "/home/container/.local/lib/python3.10/site-packages/pycord/wavelink/player.py", line 107, in guild
    return self.channel.guild
AttributeError: 'NoneType' object has no attribute 'guild'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/container/.local/lib/python3.10/site-packages/discord/ext/commands/bot.py", line 335, in invoke
    await ctx.command.invoke(ctx)
  File "/home/container/.local/lib/python3.10/site-packages/discord/ext/commands/core.py", line 916, in invoke
    await injected(*ctx.args, **ctx.kwargs)
  File "/home/container/.local/lib/python3.10/site-packages/discord/ext/commands/core.py", line 188, in wrapped
    raise CommandInvokeError(exc) from exc
discord.ext.commands.errors.CommandInvokeError: Command raised an exception: AttributeError: 'NoneType' object has no attribute 'guild'
```
