### PR TITLE
Added __anext__() if track is None

### DIFF
--- a/src/pycord/wavelink/ext/spotify/__init__.py
+++ b/src/pycord/wavelink/ext/spotify/__init__.py
@@ -156,6 +156,9 @@ class SpotifyAsyncIterator:
         except asyncio.QueueEmpty:
             raise StopAsyncIteration
 
+        if track is None:
+            return await self.__anext__()
+
         if self._partial:
             track = PartialTrack(
                 query=f'{track["name"]} - {track["artists"][0]["name"]}'


### PR DESCRIPTION
Found an exception occuring in SpotifyAsyncIterator if track is None so added a small fix for that.